### PR TITLE
Adding Envoy front proxy and monitoring

### DIFF
--- a/Dockerfile-frontenvoy
+++ b/Dockerfile-frontenvoy
@@ -1,0 +1,5 @@
+FROM envoyproxy/envoy-dev:latest
+
+RUN apt-get update && apt-get -q install -y \
+curl
+CMD /usr/local/bin/envoy -c /etc/front-envoy.yaml --service-cluster front-proxy

--- a/Dockerfile-frontenvoy
+++ b/Dockerfile-frontenvoy
@@ -2,4 +2,4 @@ FROM envoyproxy/envoy-dev:latest
 
 RUN apt-get update && apt-get -q install -y \
 curl
-CMD /usr/local/bin/envoy -c /etc/front-envoy.yaml --service-cluster front-proxy
+CMD /usr/local/bin/envoy -c /etc/front-envoy.yaml --service-cluster front-proxy -l info --service-node 'front-envoy' --log-format '[METADATA][%Y-%m-%d %T.%e][%t][%l][%n] %v'

--- a/Dockerfile-tagwatchersvcenvoy
+++ b/Dockerfile-tagwatchersvcenvoy
@@ -1,0 +1,5 @@
+FROM envoyproxy/envoy-dev:latest
+
+RUN apt-get update && apt-get -q install -y \
+curl
+CMD /usr/local/bin/envoy -c /etc/tag-watcher-svc.yaml --service-cluster tag-watcher-svc

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ NOTE: You must have Maven and Docker installed on your machine to build this pro
 
 1.  Run `mvn clean install`
 1.  Run `docker-compose up`
-1.  Navigate to [localhost:8080/hello]() to see the application running
+1.  Navigate to [localhost/hello]() to see the application running
 
 
 ### How to debug 
-The docker-compose file will start a [Jaeger](https://www.jaegertracing.io/) server to investigate distributed tracing.
-The Jaeger server is exposed here: http://localhost:8081/
+The docker-compose file will start a [Jaeger](https://www.jaegertracing.io/) server and a [Prometheus](https://prometheus.io/) server
 
+The Jaeger server is exposed here: http://localhost:8081/
+The Prometheus server is exposed here: http://localhost:9090/

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ NOTE: You must have Maven and Docker installed on your machine to build this pro
 1.  Run `mvn clean install`
 1.  Run `docker-compose up`
 1.  Navigate to [localhost:8080/hello]() to see the application running
+
+
+### How to debug 
+The docker-compose file will start a [Jaeger](https://www.jaegertracing.io/) server to investigate distributed tracing.
+The Jaeger server is exposed here: http://localhost:8081/
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-frontenvoy
-    networks:
-      - envoymesh
     volumes:
       - ./front-envoy.yaml:/etc/front-envoy.yaml
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '3'
 services:
 
-#  tag-watcher-svc:
-#    build:
-#      context: .
-#      args:
-#        # Choosing to hardcode the version for now since versioning doesn't give me any benefits right now
-#        # Could of ignored versioning all together, but now at least we have the option to deal with it later
-#        JAR_FILE: "target/tag-watcher-svc-0.0.1-SNAPSHOT.jar"
+  tag-watcher-svc:
+    build:
+      context: .
+      args:
+        # Choosing to hardcode the version for now since versioning doesn't give me any benefits right now
+        # Could of ignored versioning all together, but now at least we have the option to deal with it later
+        JAR_FILE: "target/tag-watcher-svc-0.0.1-SNAPSHOT.jar"
 
   envoy-front-proxy:
     build:
@@ -21,7 +21,7 @@ services:
       - "80"
       - "8001"
     ports:
-      - "8000:80"
+      - "80:8000"
       - "8001:8001"
 
 #  envoy-tag-watcher-svc:
@@ -30,6 +30,29 @@ services:
 #      dockerfile: Dockerfile-tagwatchersvcenvoy
 #    volumes:
 #      - ./tag-watcher-svc.yaml:/etc/tag-watcher-svc.yaml
+
+  jaeger:
+    image: jaegertracing/all-in-one
+    environment:
+      - COLLECTOR_ZIPKIN_HTTP_PORT=9411
+    ports:
+      - 9411:9411
+      - 8081:16686
+
+  statsd_exporter:
+    image: prom/statsd-exporter:latest
+    ports:
+      - "9125:9125"
+      - "9102:9102"
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus/config.yaml:/etc/prometheus.yaml
+    ports:
+      - "9090:9090"
+    command: "--config.file=/etc/prometheus.yaml"
+
 
 networks:
   envoymesh: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,35 @@
 version: '3'
 services:
 
-  tag-watcher-svc:
-    build:
-      context: .
-      args:
-        # Choosing to hardcode the version for now since versioning doesn't give me any benefits right now
-        # Could of ignored versioning all together, but now at least we have the option to deal with it later
-        JAR_FILE: "target/tag-watcher-svc-0.0.1-SNAPSHOT.jar"
+#  tag-watcher-svc:
+#    build:
+#      context: .
+#      args:
+#        # Choosing to hardcode the version for now since versioning doesn't give me any benefits right now
+#        # Could of ignored versioning all together, but now at least we have the option to deal with it later
+#        JAR_FILE: "target/tag-watcher-svc-0.0.1-SNAPSHOT.jar"
 
   envoy-front-proxy:
     build:
       context: .
       dockerfile: Dockerfile-frontenvoy
+    networks:
+      - envoymesh
     volumes:
       - ./front-envoy.yaml:/etc/front-envoy.yaml
+    expose:
+      - "80"
+      - "8001"
     ports:
       - "8000:80"
       - "8001:8001"
 
-  envoy-tag-watcher-svc:
-    build:
-      context: .
-      dockerfile: Dockerfile-tagwatchersvcenvoy
-    volumes:
-      - ./tag-watcher-svc.yaml:/etc/tag-watcher-svc.yaml
+#  envoy-tag-watcher-svc:
+#    build:
+#      context: .
+#      dockerfile: Dockerfile-tagwatchersvcenvoy
+#    volumes:
+#      - ./tag-watcher-svc.yaml:/etc/tag-watcher-svc.yaml
 
 networks:
   envoymesh: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3'
 services:
+
   tag-watcher-svc:
     build:
       context: .
@@ -7,5 +8,23 @@ services:
         # Choosing to hardcode the version for now since versioning doesn't give me any benefits right now
         # Could of ignored versioning all together, but now at least we have the option to deal with it later
         JAR_FILE: "target/tag-watcher-svc-0.0.1-SNAPSHOT.jar"
+
+  envoy-front-proxy:
+    build:
+      context: .
+      dockerfile: Dockerfile-frontenvoy
+    volumes:
+      - ./front-envoy.yaml:/etc/front-envoy.yaml
     ports:
-      - "8080:8080"
+      - "8000:80"
+      - "8001:8001"
+
+  envoy-tag-watcher-svc:
+    build:
+      context: .
+      dockerfile: Dockerfile-tagwatchersvcenvoy
+    volumes:
+      - ./tag-watcher-svc.yaml:/etc/tag-watcher-svc.yaml
+
+networks:
+  envoymesh: {}

--- a/front-envoy.yaml
+++ b/front-envoy.yaml
@@ -62,15 +62,15 @@ static_resources:
                 -
                   name: "envoy.router"
   clusters:
-    - name: "tag-watcher-svc"
-      connect_timeout: "0.25s"
-      type: "STATIC"
-      ##type: "strict_dns"
-      lb_policy: "ROUND_ROBIN"
+    - name: tag-watcher-svc
+      connect_timeout: 0.25s
+      ##type: STATIC
+      type: strict_dns
+      lb_policy: ROUND_ROBIN
       hosts:
-        -
-          socket_address:
-            address: 127.0.0.1
+        - socket_address:
+            address: tag-watcher-svc
+            ##address: 0.0.0.0
             ##address: "tag-watcher-svc-envoy"
             port_value: 8080
 

--- a/front-envoy.yaml
+++ b/front-envoy.yaml
@@ -1,43 +1,93 @@
+---
+tracing:
+  http:
+    name: envoy.zipkin
+    config:
+      collector_cluster: jaeger
+      collector_endpoint: "/api/v1/spans"
+
+stats_sinks:
+  - name: envoy.statsd
+    config:
+      tcp_cluster_name: statsd_exporter
+#      prefix: front-envoy
+
 admin:
-  access_log_path: "/dev/null"
+  access_log_path: "/tmp/admin_access.log"
   address:
     socket_address:
-      address: 0.0.0.0
+      address: "0.0.0.0"
       port_value: 8001
-
 static_resources:
   listeners:
-    - name: main-listener
+    -
+      name: "http_listener"
       address:
-        socket_address: { address: 127.0.0.1, port_value: 80 }
+        socket_address:
+          address: "0.0.0.0"
+          port_value: 8000
       filter_chains:
-        - filters:
-            - name: envoy.http_connection_manager
-              typed_config:
-                "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
-                stat_prefix: ingress_http
-                codec_type: AUTO
-                route_config:
-                  name: local_route
-                  virtual_hosts:
-                    - name: local_service
-                      domains: ["*"]
-                      routes:
-                        - match: { prefix: "/" }
-                          route: { cluster: tag-watcher-svc }
-                http_filters:
-                  - name: envoy.router
+        filters:
+          -
+            name: "envoy.http_connection_manager"
+            config:
+              tracing:
+                ##TODO switch this later
+                ##operation_name: egress
+                operation_name: ingress
+              use_remote_address: true
+              add_user_agent: true
+              access_log:
+                - name: envoy.file_access_log
+                  config:
+                    path: /dev/stdout
+                    format: "[ACCESS_LOG][%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" \"%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%\"\n"
+              stat_prefix: "ingress_8000"
+              codec_type: "AUTO"
+              generate_request_id: true
+              route_config:
+                name: "local_route"
+                virtual_hosts:
+                  -
+                    name: "http-route"
+                    domains:
+                      - "*"
+                    routes:
+                      -
+                        match:
+                          prefix: "/"
+                        route:
+                          cluster: "tag-watcher-svc"
+              http_filters:
+                -
+                  name: "envoy.router"
   clusters:
-    - name: tag-watcher-svc
+    - name: "tag-watcher-svc"
+      connect_timeout: "0.25s"
+      type: "STATIC"
+      ##type: "strict_dns"
+      lb_policy: "ROUND_ROBIN"
+      hosts:
+        -
+          socket_address:
+            address: 127.0.0.1
+            ##address: "tag-watcher-svc-envoy"
+            port_value: 8080
+
+    - name: jaeger
       connect_timeout: 0.25s
-      type: STATIC
+      type: strict_dns
+      lb_policy: round_robin
+      hosts:
+        - socket_address:
+            address: jaeger
+            port_value: 9411
+
+    - name: statsd_exporter
+      connect_timeout: 0.25s
+      type: strict_dns
       lb_policy: ROUND_ROBIN
-      load_assignment:
-        cluster_name: tag-watcher-svc
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  address:
-                    socket_address:
-                      address: 0.0.0.0
-                      port_value: 8080
+      hosts:
+        - socket_address:
+            address: statsd_exporter
+            port_value: 9125

--- a/front-envoy.yaml
+++ b/front-envoy.yaml
@@ -1,7 +1,9 @@
 admin:
-  access_log_path: /tmp/admin_access.log
+  access_log_path: "/dev/null"
   address:
-    socket_address: { address: 127.0.0.1, port_value: 8001 }
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001
 
 static_resources:
   listeners:
@@ -37,5 +39,5 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: 127.0.0.1
+                      address: 0.0.0.0
                       port_value: 8080

--- a/front-envoy.yaml
+++ b/front-envoy.yaml
@@ -1,0 +1,41 @@
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 127.0.0.1, port_value: 8001 }
+
+static_resources:
+  listeners:
+    - name: main-listener
+      address:
+        socket_address: { address: 127.0.0.1, port_value: 80 }
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: AUTO
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/" }
+                          route: { cluster: tag-watcher-svc }
+                http_filters:
+                  - name: envoy.router
+  clusters:
+    - name: tag-watcher-svc
+      connect_timeout: 0.25s
+      type: STATIC
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: tag-watcher-svc
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8080

--- a/prometheus/config.yaml
+++ b/prometheus/config.yaml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval:  15s
+scrape_configs:
+  - job_name: 'statsd'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['statsd_exporter:9102']
+        labels:
+          group: 'services'

--- a/tag-watcher-svc.yaml
+++ b/tag-watcher-svc.yaml
@@ -1,0 +1,47 @@
+static_resources:
+  listeners:
+    - address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8080
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                codec_type: auto
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: local_service
+                http_filters:
+                  - name: envoy.router
+                    typed_config: {}
+  clusters:
+    - name: tag-watcher-svc
+      connect_timeout: 0.25s
+      type: strict_dns
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: tag-watcher-svc
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8080
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8081


### PR DESCRIPTION
Adding an envoy front proxy communicating directly to the tag-watcher-svc
Also adding prometheus and jaeger, since this is an excuse to try out all the Cloud Native technologies!